### PR TITLE
Fix AppComponent standalone usage

### DIFF
--- a/hello-world-ad-app/src/app/app.component.ts
+++ b/hello-world-ad-app/src/app/app.component.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MsalService } from '@azure/msal-angular';
 import { InteractionType } from '@azure/msal-browser';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './app.component.html'
 })
 export class AppComponent {

--- a/hello-world-ad-app/src/app/app.module.ts
+++ b/hello-world-ad-app/src/app/app.module.ts
@@ -35,9 +35,9 @@ export function MSALGuardConfigFactory(): MsalGuardConfiguration {
 }
 
 @NgModule({
-  declarations: [AppComponent],
   imports: [
     BrowserModule,
+    AppComponent,
     RouterModule.forRoot(routes),
     MsalModule.forRoot(MSALInstanceFactory(), MSALGuardConfigFactory(), {
       interactionType: InteractionType.Redirect,


### PR DESCRIPTION
## Summary
- make `AppComponent` a standalone component
- import the standalone component in `AppModule`

## Testing
- `npm install --silent` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_b_6873b84cba64832d89088c2a6892ff99