### PR TITLE
Add Angular 20 modular MSAL scaffold

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "angular-with-adauth": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/angular-with-adauth",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [{
+                "replace": "src/environments/environment.ts",
+                "with": "src/environments/environment.prod.ts"
+              }],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "angular-with-adauth:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "angular-with-adauth:build:production"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "angular-with-adauth"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,24 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      clearContext: false,
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "angular-with-adauth",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@angular/core": "^20.0.0",
+    "@angular/router": "^20.0.0",
+    "@angular/forms": "^20.0.0",
+    "@angular/material": "^20.0.0",
+    "@azure/msal-angular": "^3.0.0",
+    "@azure/msal-browser": "^3.0.0",
+    "rxjs": "^7.8.2",
+    "xlsx": "^0.18.5",
+    "zone.js": "^0.15.1"
+  }
+}

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,1 @@
+/* Add global styles here */

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+})
+export class AppComponent {}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,17 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
+import { routes } from './app.routes';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { MsalRedirectComponent, provideMsal } from '@azure/msal-angular';
+import { msalConfig } from './auth/auth.config';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideRouter(routes, withEnabledBlockingInitialNavigation()),
+    provideHttpClient(),
+    provideAnimations(),
+    provideMsal(msalConfig),
+  ],
+  bootstrap: [MsalRedirectComponent],
+};

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MsalRedirectComponent } from '@azure/msal-angular';
+
+import { AppComponent } from './app.component';
+import { CoreModule } from './core/core.module';
+import { AuthModule } from './auth/auth.module';
+import { routes } from './app.routes';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    HttpClientModule,
+    RouterModule.forRoot(routes, { initialNavigation: 'enabledBlocking' }),
+    CoreModule,
+    AuthModule,
+  ],
+  bootstrap: [AppComponent, MsalRedirectComponent],
+})
+export class AppModule {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,0 +1,15 @@
+import { Routes } from '@angular/router';
+import { MsalGuard } from '@azure/msal-angular';
+
+export const routes: Routes = [
+  {
+    path: 'home',
+    loadChildren: () => import('./home/home.module').then(m => m.HomeModule),
+    canActivate: [MsalGuard],
+  },
+  {
+    path: 'sign-off',
+    loadComponent: () => import('./sign-off.component').then(m => m.SignOffComponent),
+  },
+  { path: '', pathMatch: 'full', redirectTo: 'home' },
+];

--- a/src/app/auth/auth.config.ts
+++ b/src/app/auth/auth.config.ts
@@ -1,0 +1,15 @@
+import { MsalRedirectComponent, MsalRedirectComponentConfig } from '@azure/msal-angular';
+import { IPublicClientApplication, PublicClientApplication } from '@azure/msal-browser';
+
+export const msalInstance: IPublicClientApplication = new PublicClientApplication({
+  auth: {
+    clientId: '7f6497c4-b4cd-4f51-8c4a-33856c30408b',
+    authority: 'https://login.microsoftonline.com/a1bde0b1-b0cb-453d-b3f8-764d6c1380f9',
+    redirectUri: 'http://localhost:4200/home',
+    postLogoutRedirectUri: 'http://localhost:4200/sign-off',
+  }
+});
+
+export const msalConfig: MsalRedirectComponentConfig = {
+  instance: msalInstance,
+};

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { MsalModule, MsalService, MsalGuard, MsalBroadcastService } from '@azure/msal-angular';
+import { InteractionType } from '@azure/msal-browser';
+import { msalInstance } from './auth.config';
+
+@NgModule({
+  imports: [
+    MsalModule.forRoot(msalInstance, {
+      interactionType: InteractionType.Redirect,
+      authRequest: { scopes: ['User.Read'] },
+    }, {
+      interactionType: InteractionType.Redirect,
+    }),
+  ],
+  providers: [MsalService, MsalGuard, MsalBroadcastService],
+})
+export class AuthModule {}

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { MsalService, MsalBroadcastService } from '@azure/msal-angular';
+import { InteractionStatus, AuthenticationResult, EventMessage, EventType } from '@azure/msal-browser';
+import { filter, map, Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  activeAccount$ = this.msalBroadcastService.inProgress$.pipe(
+    filter(status => status === InteractionStatus.None),
+    map(() => this.msalService.instance.getActiveAccount())
+  );
+
+  constructor(private msalService: MsalService, private msalBroadcastService: MsalBroadcastService) {
+    this.msalBroadcastService.msalSubject$
+      .pipe(filter((msg: EventMessage) => msg.eventType === EventType.LOGIN_SUCCESS))
+      .subscribe((result: EventMessage) => {
+        const payload = result.payload as AuthenticationResult;
+        this.msalService.instance.setActiveAccount(payload.account);
+      });
+  }
+
+  login(): void {
+    this.msalService.loginRedirect();
+  }
+
+  logout(): void {
+    this.msalService.logoutRedirect();
+  }
+
+  acquireTokens(scopes: string[]): Observable<AuthenticationResult> {
+    const account = this.msalService.instance.getActiveAccount();
+    return this.msalService.acquireTokenSilent({ scopes, account });
+  }
+}

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,0 +1,10 @@
+import { NgModule, Optional, SkipSelf } from '@angular/core';
+
+@NgModule({})
+export class CoreModule {
+  constructor(@Optional() @SkipSelf() parent?: CoreModule) {
+    if (parent) {
+      throw new Error('CoreModule should only be imported in AppModule');
+    }
+  }
+}

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,0 +1,3 @@
+mat-card {
+  margin: 20px;
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,16 @@
+<mat-toolbar color="primary">Home</mat-toolbar>
+
+<mat-card *ngIf="(rawIdToken$ | async) as rawIdToken && (idToken$ | async) as claims && (accessToken$ | async) as access">
+  <mat-card-content>
+    <p><strong>ID Token:</strong></p>
+    <pre>{{ rawIdToken }}</pre>
+    <p><strong>Access Token:</strong></p>
+    <pre>{{ access.accessToken }}</pre>
+    <p><strong>Claims:</strong></p>
+    <pre>{{ claims | json }}</pre>
+    <button mat-raised-button color="accent" (click)="exportTokens(rawIdToken, claims, access)">Export Tokens</button>
+    <button mat-raised-button color="warn" (click)="logout()">Logout</button>
+  </mat-card-content>
+</mat-card>
+
+<mat-progress-spinner *ngIf="!(rawIdToken$ | async)" mode="indeterminate"></mat-progress-spinner>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../auth/auth.service';
+import { Observable, map } from 'rxjs';
+import * as XLSX from 'xlsx';
+import { AuthenticationResult } from '@azure/msal-browser';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.css'],
+})
+export class HomeComponent {
+  idToken$ = this.auth.activeAccount$.pipe(map(acc => acc?.idTokenClaims));
+  rawIdToken$ = this.auth.activeAccount$.pipe(map(acc => acc?.idToken));
+  accessToken$!: Observable<AuthenticationResult>;
+
+  constructor(private auth: AuthService) {
+    this.accessToken$ = this.auth.acquireTokens(['User.Read']);
+  }
+
+  logout(): void {
+    this.auth.logout();
+  }
+
+  exportTokens(idToken: string | undefined, claims: unknown, access: AuthenticationResult): void {
+    const worksheet = XLSX.utils.json_to_sheet([{ idToken, accessToken: access.accessToken, ...claims }]);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, 'Tokens');
+    XLSX.writeFile(workbook, 'tokens.xlsx');
+  }
+}

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { HomeComponent } from './home.component';
+import { SharedMaterialModule } from '../shared/shared-material.module';
+
+@NgModule({
+  declarations: [HomeComponent],
+  imports: [CommonModule, SharedMaterialModule, RouterModule.forChild([{ path: '', component: HomeComponent }])],
+})
+export class HomeModule {}

--- a/src/app/shared/shared-material.module.ts
+++ b/src/app/shared/shared-material.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@NgModule({
+  exports: [MatButtonModule, MatToolbarModule, MatCardModule, MatProgressSpinnerModule]
+})
+export class SharedMaterialModule {}

--- a/src/app/sign-off.component.ts
+++ b/src/app/sign-off.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+
+@Component({
+  standalone: true,
+  selector: 'app-sign-off',
+  imports: [MatCardModule],
+  template: `<mat-card><p>You have been signed off</p></mat-card>`,
+})
+export class SignOffComponent {}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: true,
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  production: false,
+};

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AngularWithADAuth</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,2 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
+body { margin: 0; font-family: Roboto, Arial, sans-serif; }

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,11 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"],
+    "useDefineForClassFields": false
+  },
+  "angularCompilerOptions": {
+    "disableTypeScriptVersionCheck": true,
+    "strictInjectionParameters": true,
+    "strictInputTypes": true,
+    "strictTemplates": true
+  }
+}

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold Angular 20 project for Azure AD authentication
- configure MSAL redirect settings
- implement modular architecture with auth, core, home and shared modules
- display tokens and provide export/logout features

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68775312e258832d9083765e0405d095