### PR TITLE
Simplify home page display

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,16 +1,9 @@
 <mat-toolbar color="primary">Home</mat-toolbar>
 
-<mat-card *ngIf="(rawIdToken$ | async) as rawIdToken && (idToken$ | async) as claims && (accessToken$ | async) as access">
+<mat-card>
   <mat-card-content>
-    <p><strong>ID Token:</strong></p>
-    <pre>{{ rawIdToken }}</pre>
-    <p><strong>Access Token:</strong></p>
-    <pre>{{ access.accessToken }}</pre>
-    <p><strong>Claims:</strong></p>
-    <pre>{{ claims | json }}</pre>
-    <button mat-raised-button color="accent" (click)="exportTokens(rawIdToken, claims, access)">Export Tokens</button>
+    <p *ngIf="username$ | async as name">Logged in as {{ name }}</p>
+    <p *ngIf="!(username$ | async)">You are logged in.</p>
     <button mat-raised-button color="warn" (click)="logout()">Logout</button>
   </mat-card-content>
 </mat-card>
-
-<mat-progress-spinner *ngIf="!(rawIdToken$ | async)" mode="indeterminate"></mat-progress-spinner>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,12 +1,9 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../auth/auth.service';
-import { Observable, map } from 'rxjs';
-import * as XLSX from 'xlsx';
-import { AuthenticationResult } from '@azure/msal-browser';
+import { map } from 'rxjs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatCardModule } from '@angular/material/card';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 
 @Component({
@@ -18,28 +15,15 @@ import { MatButtonModule } from '@angular/material/button';
     CommonModule,
     MatToolbarModule,
     MatCardModule,
-    MatProgressSpinnerModule,
     MatButtonModule,
   ]
 })
 export class HomeComponent {
-  idToken$ = this.auth.activeAccount$.pipe(map(acc => acc?.idTokenClaims));
-  rawIdToken$ = this.auth.activeAccount$.pipe(map(acc => acc?.idToken));
-  accessToken$!: Observable<AuthenticationResult>;
+  username$ = this.auth.activeAccount$.pipe(map(acc => acc?.username));
 
-  constructor(private auth: AuthService) {
-    this.accessToken$ = this.auth.acquireTokens(['User.Read']);
-  }
+  constructor(private auth: AuthService) {}
 
   logout(): void {
     this.auth.logout();
-  }
-
-  exportTokens(idToken: string | undefined, claims: unknown, access: AuthenticationResult): void {
-    const claimObject = typeof claims === 'object' && claims !== null ? claims as Record<string, unknown> : {};
-    const worksheet = XLSX.utils.json_to_sheet([{ idToken, accessToken: access.accessToken, ...claimObject }]);
-    const workbook = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(workbook, worksheet, 'Tokens');
-    XLSX.writeFile(workbook, 'tokens.xlsx');
   }
 }


### PR DESCRIPTION
## Summary
- trim down the home component
- show logged in username and logout button only

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68775e6c71bc832d9f4f44680e1ab01d