### PR TITLE
Fix parent module injection for Angular 20

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,8 +1,9 @@
-import { NgModule, Optional, SkipSelf } from '@angular/core';
+import { NgModule, inject } from '@angular/core';
 
 @NgModule({})
 export class CoreModule {
-  constructor(@Optional() @SkipSelf() parent: CoreModule | null) {
+  constructor() {
+    const parent = inject(CoreModule, { optional: true, skipSelf: true });
     if (parent) {
       throw new Error('CoreModule should only be imported in AppModule');
     }


### PR DESCRIPTION
## Summary
- use `inject()` inside `CoreModule` constructor to replace unsupported parameter decorators

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877643e0778832dabb52f9d1744ee63