### PR TITLE
Fix AppComponent bootstrap

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,8 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
 
 @Component({
-  standalone: true,
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
-  imports: [RouterOutlet]
+  styleUrls: ['./app.component.css']
 })
 export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,15 +11,15 @@ import { AuthModule } from './auth/auth.module';
 import { routes } from './app.routes';
 
 @NgModule({
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     HttpClientModule,
     RouterModule.forRoot(routes, { initialNavigation: 'enabledBlocking' }),
     CoreModule,
-    AuthModule,
-    AppComponent
+    AuthModule
   ],
-  bootstrap: [AppComponent, MsalRedirectComponent],
+  bootstrap: [AppComponent, MsalRedirectComponent]
 })
 export class AppModule {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,7 +9,7 @@ export const routes: Routes = [
   },
   {
     path: 'sign-off',
-    loadComponent: () => import('./sign-off.component').then(m => m.SignOffComponent),
+    loadChildren: () => import('./sign-off.module').then(m => m.SignOffModule),
   },
   { path: '', pathMatch: 'full', redirectTo: 'home' },
 ];

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,22 +1,11 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { AuthService } from '../auth/auth.service';
 import { map } from 'rxjs';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 
 @Component({
-  standalone: true,
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css'],
-  imports: [
-    CommonModule,
-    MatToolbarModule,
-    MatCardModule,
-    MatButtonModule,
-  ]
+  styleUrls: ['./home.component.css']
 })
 export class HomeComponent {
   username$ = this.auth.activeAccount$.pipe(map(acc => acc?.username));

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -5,11 +5,11 @@ import { HomeComponent } from './home.component';
 import { SharedMaterialModule } from '../shared/shared-material.module';
 
 @NgModule({
+  declarations: [HomeComponent],
   imports: [
     CommonModule,
     SharedMaterialModule,
     RouterModule.forChild([{ path: '', component: HomeComponent }]),
-    HomeComponent,
   ],
 })
 export class HomeModule {}

--- a/src/app/sign-off.component.ts
+++ b/src/app/sign-off.component.ts
@@ -1,10 +1,6 @@
 import { Component } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-
 @Component({
-  standalone: true,
   selector: 'app-sign-off',
-  imports: [MatCardModule],
   template: `<mat-card><p>You have been signed off</p></mat-card>`,
 })
 export class SignOffComponent {}

--- a/src/app/sign-off.module.ts
+++ b/src/app/sign-off.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatCardModule } from '@angular/material/card';
+
+import { SignOffComponent } from './sign-off.component';
+
+@NgModule({
+  declarations: [SignOffComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    RouterModule.forChild([{ path: '', component: SignOffComponent }])
+  ],
+})
+export class SignOffModule {}


### PR DESCRIPTION
## Summary
- switch `AppComponent` back to NgModule style
- declare `AppComponent` in `AppModule`
- convert standalone components to NgModules

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68776d812a28832d8507eeca4b8adaba